### PR TITLE
Avoid musl's default allocator due to lackluster performance.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,8 +99,11 @@ windows = {version = "0.59", features = ["Win32_Globalization","Win32_System_Sys
 # https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#platform-specific-dependencies
 # https://doc.rust-lang.org/reference/conditional-compilation.html
 [target.'cfg(target_env = "gnu")'.dependencies]
+openssl = { version = "0.10", features = ["vendored"] }
+
 [target.'cfg(target_env = "musl")'.dependencies]
 openssl = { version = "0.10", features = ["vendored"] }
+mimalloc = "0.1.43"
 
 [profile.dev]
 debug = 2

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 # ✨ Features
 * 🛒 **Light** Only ONE executable file, it can run smoothly on laptops without GPUs (data files will be created at runtime automatically).
-* 🐱‍🏍 **AI powered** Integrated `Huggingface local model`, `Ollama` and `OpenAI`, this can be used for `Chat`, `Text generation` and `Intent detection`.
+* 🐱‍🏍 **AI powered** Integrated `Huggingface local models (Llama, Phi-3, Gemma, Multilingual E5, MiniLM L6v2, NomicEmbedTextV1_5, etc.)`, `Ollama` and `OpenAI`, this can be used for `Chat`, `Text generation` and `Intent detection`.
 * 🚀 **Fast** Built on Rust and Vue3.
 * 😀 **Simple** Use the mouse to drag and drop with our intuitive node-based editor.
 * 🔐 **Safe** 100% open source, all runtime data is saved locally (Using `OpenAI API` may expose some data).

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,12 @@ use tokio::runtime::Builder;
 
 use dialogflow::web::server::start_app;
 
+// Avoid musl's default allocator due to lackluster performance
+// https://nickb.dev/blog/default-musl-allocator-considered-harmful-to-performance
+#[cfg(target_env = "musl")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 fn main() {
     // dialogflow::web::t1();
     unsafe {


### PR DESCRIPTION
Since the default allocator is pretty slow in MUSL, so I tried to use `mimalloc` instead.